### PR TITLE
mol2rdkit_phys_chem: make failure on any error optional

### DIFF
--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -154,11 +154,11 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
         parent_dict = dict(super().get_params(deep=deep))
         if deep:
             parent_dict["descriptor_list"] = copy.deepcopy(self._descriptor_list)
-            parent_dict["fails_on_any_error"] = copy.deepcopy(self._return_with_errors)
+            parent_dict["return_with_errors"] = copy.deepcopy(self._return_with_errors)
             parent_dict["log_exceptions"] = copy.deepcopy(self._log_exceptions)
         else:
             parent_dict["descriptor_list"] = self._descriptor_list
-            parent_dict["fails_on_any_error"] = self._return_with_errors
+            parent_dict["return_with_errors"] = self._return_with_errors
             parent_dict["log_exceptions"] = self._log_exceptions
         return parent_dict
 
@@ -176,7 +176,7 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
             Self
         """
         parameters_shallow_copy = dict(parameters)
-        params_list = ["descriptor_list", "fails_on_any_error", "log_exceptions"]
+        params_list = ["descriptor_list", "return_with_errors", "log_exceptions"]
         for param_name in params_list:
             if param_name in parameters:
                 setattr(self, f"_{param_name}", parameters[param_name])

--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -72,9 +72,11 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
             UUID of the PipelineElement. If None, a new UUID is generated.
         """
         if descriptor_list is not None:
-            for name in descriptor_list:
-                if name not in RDKIT_DESCRIPTOR_DICT:
-                    raise ValueError(f"Unknown descriptor function with name: {name}")
+            for descriptor_name in descriptor_list:
+                if descriptor_name not in RDKIT_DESCRIPTOR_DICT:
+                    raise ValueError(
+                        f"Unknown descriptor function with name: {descriptor_name}"
+                    )
             self._descriptor_list = descriptor_list
         else:
             self._descriptor_list = DEFAULT_DESCRIPTORS
@@ -129,7 +131,7 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
             descriptor_func = RDKIT_DESCRIPTOR_DICT[name]
             try:
                 vec[i] = descriptor_func(value)
-            except Exception as e:
+            except Exception:  # pylint: disable=broad-except
                 if self._log_exceptions:
                     logger.exception(f"Failed calculating descriptor: {name}")
         if not self._return_with_errors and np.any(np.isnan(vec)):

--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -71,15 +71,7 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
         uuid: Optional[str], optional (default=None)
             UUID of the PipelineElement. If None, a new UUID is generated.
         """
-        if descriptor_list is not None:
-            for descriptor_name in descriptor_list:
-                if descriptor_name not in RDKIT_DESCRIPTOR_DICT:
-                    raise ValueError(
-                        f"Unknown descriptor function with name: {descriptor_name}"
-                    )
-            self._descriptor_list = descriptor_list
-        else:
-            self._descriptor_list = DEFAULT_DESCRIPTORS
+        self.descriptor_list = descriptor_list
         self._return_with_errors = return_with_errors
         self._log_exceptions = log_exceptions
         super().__init__(
@@ -110,6 +102,20 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
             List of descriptor names.
         """
         return self._descriptor_list[:]
+
+    @descriptor_list.setter
+    def descriptor_list(self, descriptor_list: list[str] | None) -> None:
+        if descriptor_list is None or descriptor_list is DEFAULT_DESCRIPTORS:
+            # if None or DEFAULT_DESCRIPTORS are used, set the default descriptors
+            self._descriptor_list = DEFAULT_DESCRIPTORS
+        else:
+            # check all user defined descriptors are valid
+            for descriptor_name in descriptor_list:
+                if descriptor_name not in RDKIT_DESCRIPTOR_DICT:
+                    raise ValueError(
+                        f"Unknown descriptor function with name: {descriptor_name}"
+                    )
+            self._descriptor_list = descriptor_list
 
     def pretransform_single(
         self, value: RDKitMol

--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -71,7 +71,7 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
         uuid: Optional[str], optional (default=None)
             UUID of the PipelineElement. If None, a new UUID is generated.
         """
-        self.descriptor_list = descriptor_list
+        self.descriptor_list = descriptor_list  # type: ignore
         self._return_with_errors = return_with_errors
         self._log_exceptions = log_exceptions
         super().__init__(
@@ -105,6 +105,18 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
 
     @descriptor_list.setter
     def descriptor_list(self, descriptor_list: list[str] | None) -> None:
+        """Set the descriptor list.
+
+        Parameters
+        ----------
+        descriptor_list: list[str] | None
+            List of descriptor names to calculate. If None, DEFAULT_DESCRIPTORS are used.
+
+        Raises
+        ------
+        ValueError
+            If an unknown descriptor name is used.
+        """
         if descriptor_list is None or descriptor_list is DEFAULT_DESCRIPTORS:
             # if None or DEFAULT_DESCRIPTORS are used, set the default descriptors
             self._descriptor_list = DEFAULT_DESCRIPTORS

--- a/tests/test_elements/test_mol2any/test_mol2rdkit_phys_chem.py
+++ b/tests/test_elements/test_mol2any/test_mol2rdkit_phys_chem.py
@@ -321,7 +321,7 @@ class TestMol2RDKitPhyschem(unittest.TestCase):
         )
 
         # note that we need the error filter and replacer here. Otherwise, the pipeline would fail on any error
-        # irrespective of the fails_on_any_error parameter
+        # irrespective of the return_with_errors parameter
         pipeline = Pipeline(
             [
                 ("smi2mol", SmilesToMol()),

--- a/tests/test_elements/test_mol2any/test_mol2rdkit_phys_chem.py
+++ b/tests/test_elements/test_mol2any/test_mol2rdkit_phys_chem.py
@@ -377,7 +377,7 @@ class TestMol2RDKitPhyschem(unittest.TestCase):
         self.assertRaises(
             ValueError,
             MolToRDKitPhysChem,
-            **{"descriptor_list": ["__NotADescriptor11Name4374737834hggghgddd"]},
+            **{"descriptor_list": ["__NotADescriptor11Name:)"]},
         )
 
     def test_exception_handling(self) -> None:


### PR DESCRIPTION
Add a parameter fails_on_any_error to MolToRDKitPhysChem to get partial results when the computation of a single physchem descriptor fails.

This feature is necessary for data analysis, where we want to examine data even if one of 200 descriptors failed to be calculated.