### PR TITLE
Fix scorer sign error

### DIFF
--- a/molpipeline/metrics/ignore_error_scorer.py
+++ b/molpipeline/metrics/ignore_error_scorer.py
@@ -39,6 +39,8 @@ def ignored_value_scorer(
     score_func = scorer._score_func  # pylint: disable=protected-access
     response_method = scorer._response_method  # pylint: disable=protected-access
     scorer_kwargs = scorer._kwargs  # pylint: disable=protected-access
+    if scorer._sign < 0: # pylint: disable=protected-access
+        scorer_kwargs["greater_is_better"] = False
 
     def newscore(
         y_true: npt.NDArray[np.float_ | np.int_],

--- a/tests/test_metrics/test_ignore_error_scorer.py
+++ b/tests/test_metrics/test_ignore_error_scorer.py
@@ -3,8 +3,10 @@
 import unittest
 
 import numpy as np
+from sklearn import linear_model
 
 from molpipeline.metrics import ignored_value_scorer
+from sklearn.metrics import get_scorer
 
 
 class IgnoreErrorScorerTest(unittest.TestCase):
@@ -44,4 +46,40 @@ class IgnoreErrorScorerTest(unittest.TestCase):
         self.assertAlmostEqual(
             ba_score._score_func(y_true, y_pred),  # pylint: disable=protected-access
             1.0,
+        )
+    
+    def test_correct_init_mse(self) -> None:
+        """Test that initialization is correct as we access via protected vars."""
+        x_train = np.array([0.1,0.2, 0.3,0.4,0.5,0.6,0.7,0.8,0.9,1]).reshape(-1, 1)
+        y_train = np.array([0.1,0.3, 0.3,0.4,0.5,0.5,0.7,0.88,0.9,1])
+        regr = linear_model.LinearRegression()
+        regr.fit(x_train, y_train)
+        cix_scorer = ignored_value_scorer("neg_mean_squared_error", None)
+        scikit_scorer = get_scorer("neg_mean_squared_error")
+        self.assertEqual(
+            cix_scorer(regr, x_train,y_train), scikit_scorer(regr, x_train,y_train)
+        )
+    
+    def test_correct_init_rmse(self) -> None:
+        """Test that initialization is correct as we access via protected vars."""
+        x_train = np.array([0.1,0.2, 0.3,0.4,0.5,0.6,0.7,0.8,0.9,1]).reshape(-1, 1)
+        y_train = np.array([0.1,0.3, 0.3,0.4,0.5,0.5,0.7,0.88,0.9,1])
+        regr = linear_model.LinearRegression()
+        regr.fit(x_train, y_train)
+        cix_scorer = ignored_value_scorer("neg_root_mean_squared_error", None)
+        scikit_scorer = get_scorer("neg_root_mean_squared_error")
+        self.assertEqual(
+            cix_scorer(regr, x_train,y_train), scikit_scorer(regr, x_train,y_train)
+        )
+    
+    def test_correct_init_inheritance(self) -> None:
+        """Test that initialization is correct if we pass an initialized scorer."""
+        x_train = np.array([0.1,0.2, 0.3,0.4,0.5,0.6,0.7,0.8,0.9,1]).reshape(-1, 1)
+        y_train = np.array([0.1,0.3, 0.3,0.4,0.5,0.5,0.7,0.88,0.9,1])
+        regr = linear_model.LinearRegression()
+        regr.fit(x_train, y_train)
+        scikit_scorer = get_scorer("neg_root_mean_squared_error")
+        cix_scorer = ignored_value_scorer(get_scorer("neg_root_mean_squared_error"), None)
+        self.assertEqual(
+            cix_scorer(regr, x_train,y_train), scikit_scorer(regr, x_train,y_train)
         )


### PR DESCRIPTION
This PR fixes a bug where loss functions were not instantiated correctly when using ignored_value_scorer as the sign was not considered