### PR TITLE
.github: add test coverage with threshold

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -177,10 +177,14 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
+          pip install coverage
           pip install .
       - name: Run unit-tests
         run: |
-          python -m unittest discover -v -s tests -t .
+          # Run only the core test suite in the tests directory.
+          coverage run -m unittest discover tests
+          # Create a coverage report. Fail if the coverage is below 85%. Exclude extra packages from the report.
+          coverage report --fail-under=85 --omit="*chemprop*","*/*chemprop*/*"
 
   test_chemprop:
     needs:
@@ -195,11 +199,15 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
+          pip install coverage
           pip install torch
           pip install .[chemprop]
       - name: Run unit-tests for chemprop
         run: |
-          python -m unittest discover -v -s test_extras/test_chemprop -t .
+          # Run only the chemprop test suite.
+          coverage run -m unittest discover test_extras/test_chemprop
+          # Create a coverage report. Fail if the coverage is below 85%. Include only chemprop files in the report.
+          coverage report --fail-under=85 --include="*chemprop*","*/*chemprop*/*"
 
   test_notebooks:
     needs:


### PR DESCRIPTION
    - Execute the unittests with the coverage module instead
      of using the unittests module directly.
    - Introduce a threshold for code coverage. If the coverage
      will shrink below the threshold the CI/CD pipeline will
      fail.
    - Collect coverage separately for the core test suite and
      extra packages like chemprop.