### PR TITLE
remove pandas version fix

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -222,7 +222,6 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install "pandas<2.2.0"
           pip install .[notebooks]
       - name: Run unit-tests for notebooks
         run: |


### PR DESCRIPTION
Due to the delayed rdkti release we had to pin the pandas version. Since rdkit is now updated, this can be removed.