### PR TITLE
Block logs for physchem descriptors

### DIFF
--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -16,6 +16,7 @@ import copy
 import numpy as np
 import numpy.typing as npt
 from loguru import logger
+from rdkit import rdBase
 from rdkit import Chem
 from rdkit.Chem import Descriptors
 from sklearn.preprocessing import StandardScaler
@@ -133,6 +134,7 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
             Descriptor vector for given molecule. None if calculation failed.
         """
         vec = np.full((len(self._descriptor_list),), np.nan)
+        log_block = rdBase.BlockLogs()  # pylint: disable=unused-variable
         for i, name in enumerate(self._descriptor_list):
             descriptor_func = RDKIT_DESCRIPTOR_DICT[name]
             try:
@@ -140,6 +142,7 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
             except Exception:  # pylint: disable=broad-except
                 if self._log_exceptions:
                     logger.exception(f"Failed calculating descriptor: {name}")
+        del log_block
         if not self._return_with_errors and np.any(np.isnan(vec)):
             return InvalidInstance(self.uuid, "NaN in descriptor vector", self.name)
         return vec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Jochen Sieg"}
 ]
 description = "Integration of rdkit functionality into sklearn pipelines."
-version = "0.8.4"
+version = "0.8.5"
 readme = "README.md"
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
This is only temporally, as long [fp_density](https://github.com/rdkit/rdkit/blame/db0e71bc1c002fa1f0fdc4f678488b6d1464d7aa/rdkit/Chem/Descriptors.py#L202) is using deprecated code.