### PR TITLE
mol2morgan_fingerprint: remove deprecated fp function

### DIFF
--- a/molpipeline/mol2any/mol2morgan_fingerprint.py
+++ b/molpipeline/mol2any/mol2morgan_fingerprint.py
@@ -151,12 +151,11 @@ class MolToMorganFP(ABCMorganFingerprintPipelineElement):
         dict[int, list[tuple[int, int]]]
             Dictionary with bit position as key and list of tuples with atom index and radius as value.
         """
-        bit_info: dict[int, list[tuple[int, int]]] = {}
-        _ = AllChem.GetMorganFingerprintAsBitVect(
-            mol_obj,
-            self.radius,
-            useFeatures=self._use_features,
-            bitInfo=bit_info,
-            nBits=self._n_bits,
+        fp_generator = self._get_fp_generator()
+        additional_output = AllChem.AdditionalOutput()
+        additional_output.AllocateBitInfoMap()
+        _ = fp_generator.GetSparseFingerprint(
+            mol_obj, additionalOutput=additional_output
         )
+        bit_info = additional_output.GetBitInfoMap()
         return bit_info

--- a/tests/test_elements/test_mol2any/test_mol2morgan_fingerprint.py
+++ b/tests/test_elements/test_mol2any/test_mol2morgan_fingerprint.py
@@ -128,6 +128,27 @@ class TestMol2MorganFingerprint(unittest.TestCase):
         }
         self.assertRaises(ValueError, mol_fp.set_params, **params)
 
+    def test_bit2atom_mapping(self) -> None:
+        """Test that the mapping from bits to atom weights works as intended."""
+        # lower n_bit values, e.g. 2048, will lead to a bit clash during folding,
+        # for the test smiles "NCCOCCCC(=O)O".
+        # We want no folding clashes in this test to check the correct length
+        # of the bit-to-atom mapping.
+        n_bits = 2100
+        sparse_morgan = MolToMorganFP(radius=2, n_bits=n_bits, return_as="sparse")
+        dense_morgan = MolToMorganFP(radius=2, n_bits=n_bits, return_as="dense")
+        explicit_bit_vect_morgan = MolToMorganFP(
+            radius=2, n_bits=n_bits, return_as="explicit_bit_vect"
+        )
+
+        smi2mol = SmilesToMol()
+        for test_smi in test_smiles:
+            for fp_gen in [sparse_morgan, dense_morgan, explicit_bit_vect_morgan]:
+                mol = smi2mol.transform([test_smi])[0]
+                fp = fp_gen.transform([mol])
+                mapping = fp_gen.bit2atom_mapping(mol)
+                self.assertEqual(np.sum(fp), len(mapping))  # type: ignore
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
    - Remove AllChem.GetMorganFingerprintAsBitVect
      from the code because it is deprecated.
    - Add a test to ensure the bit2atom mapping works
      as intended.