### PR TITLE
mol2morgan_fingerprint: fix bug of mismatched indices after folding

### DIFF
--- a/molpipeline/mol2any/mol2morgan_fingerprint.py
+++ b/molpipeline/mol2any/mol2morgan_fingerprint.py
@@ -154,8 +154,7 @@ class MolToMorganFP(ABCMorganFingerprintPipelineElement):
         fp_generator = self._get_fp_generator()
         additional_output = AllChem.AdditionalOutput()
         additional_output.AllocateBitInfoMap()
-        _ = fp_generator.GetSparseFingerprint(
-            mol_obj, additionalOutput=additional_output
-        )
+        # using the dense fingerprint here, to get indices after folding
+        _ = fp_generator.GetFingerprint(mol_obj, additionalOutput=additional_output)
         bit_info = additional_output.GetBitInfoMap()
         return bit_info

--- a/tests/test_elements/test_mol2any/test_mol2morgan_fingerprint.py
+++ b/tests/test_elements/test_mol2any/test_mol2morgan_fingerprint.py
@@ -130,16 +130,8 @@ class TestMol2MorganFingerprint(unittest.TestCase):
         self.assertRaises(ValueError, mol_fp.set_params, **params)
 
     def test_bit2atom_mapping(self) -> None:
-        """Test that the mapping from bits to atom weights works as intended.
-
-        Notes
-        -----
-        lower n_bit values, e.g. 2048, will lead to a bit clash during folding,
-        for the test smiles "NCCOCCCC(=O)O".
-        We want no folding clashes in this test to check the correct length
-        of the bit-to-atom mapping.
-        """
-        n_bits = 2100
+        """Test that the mapping from bits to atom weights works as intended."""
+        n_bits = 2048
         sparse_morgan = MolToMorganFP(radius=2, n_bits=n_bits, return_as="sparse")
         dense_morgan = MolToMorganFP(radius=2, n_bits=n_bits, return_as="dense")
         explicit_bit_vect_morgan = MolToMorganFP(


### PR DESCRIPTION
- _explain_rdmol generated a sparse fingeprint not considering folding of the fingerprint. This led to GetBitInfoMap to return indices corresponding to the non-folded fingerprint. These indices lead to out-of-bounds errors for folded dense fingerprints.
- Fixed this by generating a dense fingerprint in the _explain_rdmol function.
- This fix is needed for the explainability module.