### PR TITLE
102 bug remove irrelevant params fails for int vaules

### DIFF
--- a/molpipeline/utils/comparison.py
+++ b/molpipeline/utils/comparison.py
@@ -32,6 +32,8 @@ def remove_irrelevant_params(params: _T) -> _T:
     if isinstance(params, dict):
         params_new = {}
         for key, value in params.items():
+            if not isinstance(key, str):
+                continue
             if key.split("__")[-1] in irrelevant_params:
                 continue
             params_new[key] = remove_irrelevant_params(value)

--- a/tests/test_utils/test_comparison.py
+++ b/tests/test_utils/test_comparison.py
@@ -1,5 +1,6 @@
 """Test the comparison functions."""
 
+from typing import Callable
 from unittest import TestCase
 
 from molpipeline.utils.comparison import check_pipelines_equivalent

--- a/tests/test_utils/test_comparison.py
+++ b/tests/test_utils/test_comparison.py
@@ -22,8 +22,8 @@ class TestComparison(TestCase):
             get_morgan_physchem_rf_pipeline,
         ]
         for pipeline_method in pipline_method_list:
-            pipeline_a = pipeline_method()
-            pipeline_b = pipeline_method()
+            pipeline_a = pipeline_method(1)
+            pipeline_b = pipeline_method(1)
             self.assertTrue(check_pipelines_equivalent(pipeline_a, pipeline_b))
 
     def test_are_not_equal(self) -> None:

--- a/tests/test_utils/test_comparison.py
+++ b/tests/test_utils/test_comparison.py
@@ -3,6 +3,7 @@
 from typing import Callable
 from unittest import TestCase
 
+from molpipeline import Pipeline
 from molpipeline.utils.comparison import check_pipelines_equivalent
 from tests.utils.default_models import (
     get_morgan_physchem_rf_pipeline,
@@ -16,11 +17,11 @@ class TestComparison(TestCase):
     def test_are_equal(self) -> None:
         """Test if two equivalent pipelines are detected as such."""
         # Test standardization pipelines
-        pipline_method_list = [
+        pipline_method_list: list[Callable[[int], Pipeline]] = [
             get_standardization_pipeline,
             get_morgan_physchem_rf_pipeline,
         ]
-        for pipeline_method in pipline_method_list:  # type: Callable[[int], Pipeline]
+        for pipeline_method in pipline_method_list:
             pipeline_a = pipeline_method()
             pipeline_b = pipeline_method()
             self.assertTrue(check_pipelines_equivalent(pipeline_a, pipeline_b))

--- a/tests/test_utils/test_comparison.py
+++ b/tests/test_utils/test_comparison.py
@@ -19,7 +19,7 @@ class TestComparison(TestCase):
             get_standardization_pipeline,
             get_morgan_physchem_rf_pipeline,
         ]
-        for pipeline_method in pipline_method_list:
+        for pipeline_method in pipline_method_list:  # type: Callable[[int], Pipeline]
             pipeline_a = pipeline_method()
             pipeline_b = pipeline_method()
             self.assertTrue(check_pipelines_equivalent(pipeline_a, pipeline_b))

--- a/tests/test_utils/test_comparison.py
+++ b/tests/test_utils/test_comparison.py
@@ -3,7 +3,10 @@
 from unittest import TestCase
 
 from molpipeline.utils.comparison import check_pipelines_equivalent
-from tests.utils.default_models import get_morgan_physchem_rf_pipeline
+from tests.utils.default_models import (
+    get_morgan_physchem_rf_pipeline,
+    get_standardization_pipeline,
+)
 
 
 class TestComparison(TestCase):
@@ -11,10 +14,15 @@ class TestComparison(TestCase):
 
     def test_are_equal(self) -> None:
         """Test if two equivalent pipelines are detected as such."""
-
-        pipeline_a = get_morgan_physchem_rf_pipeline()
-        pipeline_b = get_morgan_physchem_rf_pipeline()
-        self.assertTrue(check_pipelines_equivalent(pipeline_a, pipeline_b))
+        # Test standardization pipelines
+        pipline_method_list = [
+            get_standardization_pipeline,
+            get_morgan_physchem_rf_pipeline,
+        ]
+        for pipeline_method in pipline_method_list:
+            pipeline_a = pipeline_method()
+            pipeline_b = pipeline_method()
+            self.assertTrue(check_pipelines_equivalent(pipeline_a, pipeline_b))
 
     def test_are_not_equal(self) -> None:
         """Test if two different pipelines are detected as such."""

--- a/tests/utils/default_models.py
+++ b/tests/utils/default_models.py
@@ -79,34 +79,12 @@ def get_standardization_pipeline(n_jobs: int = 1) -> Pipeline:
     Pipeline
         The standardization pipeline.
     """
-    element_filter = ElementFilter(
-        allowed_element_numbers=[
-            1,  # H
-            3,  # Li
-            5,  # B
-            6,  # C
-            7,  # N
-            8,  # O
-            9,  # F
-            11,  # Na
-            12,  # Mg
-            14,  # Si
-            15,  # P
-            16,  # S
-            17,  # Cl
-            19,  # K
-            20,  # Ca
-            34,  # Se
-            35,  # Br
-            53,  # I
-        ],
-    )
     error_filter = ErrorFilter(filter_everything=True)
     # Set up pipeline
     standardization_pipeline = Pipeline(
         [
             ("smi2mol", SmilesToMol()),
-            ("element_filter", element_filter),
+            ("element_filter", ElementFilter()),
             ("metal_disconnector", MetalDisconnector()),
             ("salt_remover", SaltRemover()),
             ("uncharge1", Uncharger()),

--- a/tests/utils/default_models.py
+++ b/tests/utils/default_models.py
@@ -84,9 +84,9 @@ def get_standardization_pipeline(n_jobs: int = 1) -> Pipeline:
     standardization_pipeline = Pipeline(
         [
             ("smi2mol", SmilesToMol()),
-            ("element_filter", ElementFilter()),
             ("metal_disconnector", MetalDisconnector()),
             ("salt_remover", SaltRemover()),
+            ("element_filter", ElementFilter()),
             ("uncharge1", Uncharger()),
             ("canonical_tautomer", TautomerCanonicalizer()),
             ("uncharge2", Uncharger()),

--- a/tests/utils/default_models.py
+++ b/tests/utils/default_models.py
@@ -25,8 +25,13 @@ from molpipeline.mol2mol.filter import ElementFilter
 from molpipeline.post_prediction import PostPredictionWrapper
 
 
-def get_morgan_physchem_rf_pipeline() -> Pipeline:
+def get_morgan_physchem_rf_pipeline(n_jobs: int = 1) -> Pipeline:
     """Get a pipeline combining Morgan fingerprints and physicochemical properties with a RandomForestClassifier.
+
+    Parameters
+    ----------
+    n_jobs: int, default=-1
+        Number of parallel jobs to use.
 
     Returns
     -------
@@ -47,7 +52,7 @@ def get_morgan_physchem_rf_pipeline() -> Pipeline:
                 ),
             ),
             ("error_filter", error_filter),
-            ("rf", RandomForestClassifier()),
+            ("rf", RandomForestClassifier(n_jobs=n_jobs)),
             (
                 "filter_reinserter",
                 PostPredictionWrapper(
@@ -55,12 +60,12 @@ def get_morgan_physchem_rf_pipeline() -> Pipeline:
                 ),
             ),
         ],
-        n_jobs=1,
+        n_jobs=n_jobs,
     )
     return pipeline
 
 
-def get_standardization_pipeline(n_jobs: int = -1) -> Pipeline:
+def get_standardization_pipeline(n_jobs: int = 1) -> Pipeline:
     """Get the standardization pipeline.
 
     Parameters


### PR DESCRIPTION
Pipeline Elements may contain dicts which are not param-dicts. These may not necessarily have str values as keys, breaking the split method. This PR checks if the dict has str-keys prior to spliting the str.