### PR TITLE
mol2any: get feature names from elements

### DIFF
--- a/molpipeline/abstract_pipeline_elements/mol2any/mol2bitvector.py
+++ b/molpipeline/abstract_pipeline_elements/mol2any/mol2bitvector.py
@@ -33,6 +33,7 @@ class MolToFingerprintPipelineElement(MolToAnyPipelineElement, abc.ABC):
     """Abstract class for PipelineElements which transform molecules to integer vectors."""
 
     _n_bits: int
+    _feature_names: list[str]
     _output_type = "binary"
     _return_as: OutputDatatype
 
@@ -70,6 +71,11 @@ class MolToFingerprintPipelineElement(MolToAnyPipelineElement, abc.ABC):
     def n_bits(self) -> int:
         """Get number of bits in (or size of) fingerprint."""
         return self._n_bits
+
+    @property
+    def feature_names(self) -> list[str]:
+        """Get feature names."""
+        return self._feature_names[:]
 
     @overload
     def assemble_output(  # type: ignore

--- a/molpipeline/abstract_pipeline_elements/mol2any/mol2floatvector.py
+++ b/molpipeline/abstract_pipeline_elements/mol2any/mol2floatvector.py
@@ -29,6 +29,7 @@ class MolToDescriptorPipelineElement(MolToAnyPipelineElement):
 
     _standardizer: Optional[AnyTransformer]
     _output_type = "float"
+    _feature_names: list[str]
 
     def __init__(
         self,
@@ -65,6 +66,11 @@ class MolToDescriptorPipelineElement(MolToAnyPipelineElement):
     @abc.abstractmethod
     def n_features(self) -> int:
         """Return the number of features."""
+
+    @property
+    def feature_names(self) -> list[str]:
+        """Return a copy of the feature names."""
+        return self._feature_names[:]
 
     def assemble_output(
         self,

--- a/molpipeline/mol2any/mol2concatinated_vector.py
+++ b/molpipeline/mol2any/mol2concatinated_vector.py
@@ -164,7 +164,8 @@ class MolToConcatenatedVector(MolToAnyPipelineElement):
         else:
             self._output_type = "mixed"
         self._requires_fitting = any(
-            element[1]._requires_fitting for element in element_list  # type: ignore[protected-access]
+            element[1]._requires_fitting
+            for element in element_list  # pylint: disable=protected-access
         )
 
     def get_params(self, deep: bool = True) -> dict[str, Any]:
@@ -204,13 +205,20 @@ class MolToConcatenatedVector(MolToAnyPipelineElement):
 
         Parameters
         ----------
-        element_list: list[tuple[str, MolToAnyPipelineElement]]
-            List of pipeline elements.
+        parameter_copy: dict[str, Any]
+            Copy of parameters.
+        parameters: Any
+            Original parameters.
 
         Raises
         ------
         ValueError
             If element_list is empty.
+
+        Returns
+        -------
+        tuple[dict[str, Any], dict[str, Any]]
+            Updated parameter_copy and parameters.
         """
         element_list = parameter_copy.pop("element_list", None)
         if element_list is not None:

--- a/molpipeline/mol2any/mol2concatinated_vector.py
+++ b/molpipeline/mol2any/mol2concatinated_vector.py
@@ -11,9 +11,8 @@ except ImportError:
 
 import numpy as np
 import numpy.typing as npt
-from sklearn.base import clone
-
 from loguru import logger
+from sklearn.base import clone
 
 from molpipeline.abstract_pipeline_elements.core import (
     InvalidInstance,

--- a/molpipeline/mol2any/mol2concatinated_vector.py
+++ b/molpipeline/mol2any/mol2concatinated_vector.py
@@ -164,8 +164,8 @@ class MolToConcatenatedVector(MolToAnyPipelineElement):
         else:
             self._output_type = "mixed"
         self._requires_fitting = any(
-            element[1]._requires_fitting
-            for element in element_list  # pylint: disable=protected-access
+            element[1]._requires_fitting  # pylint: disable=protected-access
+            for element in element_list
         )
 
     def get_params(self, deep: bool = True) -> dict[str, Any]:

--- a/molpipeline/mol2any/mol2concatinated_vector.py
+++ b/molpipeline/mol2any/mol2concatinated_vector.py
@@ -96,15 +96,16 @@ class MolToConcatenatedVector(MolToAnyPipelineElement):
     @property
     def feature_names(self) -> list[str]:
         """Return the feature names of concatenated elements."""
-        if self._feature_names_prefix is None:
-            # use element name as prefix
-            prefix_function = lambda elem_name: elem_name
-        else:
-            prefix_function = lambda elem_name: f"{self._feature_names_prefix}"
         feature_names = []
         for name, element in self._element_list:
+            if self._feature_names_prefix is None:
+                # use element name as prefix
+                prefix = name
+            else:
+                # use user specified prefix
+                prefix = self._feature_names_prefix
+
             if hasattr(element, "feature_names"):
-                prefix = prefix_function(name)
                 feature_names.extend(
                     [f"{prefix}__{feature}" for feature in element.feature_names]
                 )

--- a/molpipeline/mol2any/mol2maccs_key_fingerprint.py
+++ b/molpipeline/mol2any/mol2maccs_key_fingerprint.py
@@ -21,6 +21,7 @@ class MolToMACCSFP(MolToFingerprintPipelineElement):
     """
 
     _n_bits = 167  # MACCS keys have 166 bits + 1 bit for an all-zero vector (bit 0)
+    _feature_names = [f"maccs_{i}" for i in range(_n_bits)]
 
     def pretransform_single(
         self, value: RDKitMol

--- a/molpipeline/mol2any/mol2morgan_fingerprint.py
+++ b/molpipeline/mol2any/mol2morgan_fingerprint.py
@@ -83,6 +83,7 @@ class MolToMorganFP(ABCMorganFingerprintPipelineElement):
                 f"Number of bits has to be a positve integer, which is > 0! (Received: {n_bits})"
             )
         self._n_bits = n_bits
+        self._feature_names = [f"morgan_{i}" for i in range(self._n_bits)]
 
     def get_params(self, deep: bool = True) -> dict[str, Any]:
         """Return all parameters defining the object.

--- a/molpipeline/mol2any/mol2net_charge.py
+++ b/molpipeline/mol2any/mol2net_charge.py
@@ -56,6 +56,7 @@ class MolToNetCharge(MolToDescriptorPipelineElement):
             UUID of the pipeline element, by default None
         """
         self._descriptor_list = ["NetCharge"]
+        self._feature_names = self._descriptor_list
         self._charge_method = charge_method
         # pylint: disable=R0801
         super().__init__(
@@ -72,7 +73,7 @@ class MolToNetCharge(MolToDescriptorPipelineElement):
 
     @property
     def descriptor_list(self) -> list[str]:
-        """Return a copy of the descriptor list."""
+        """Return a copy of the descriptor list. Alias of `feature_names`."""
         return self._descriptor_list[:]
 
     def _get_net_charge_gasteiger(

--- a/molpipeline/mol2any/mol2path_fingerprint.py
+++ b/molpipeline/mol2any/mol2path_fingerprint.py
@@ -21,7 +21,7 @@ from molpipeline.abstract_pipeline_elements.mol2any.mol2bitvector import (
 class Mol2PathFP(
     MolToRDKitGenFPElement
 ):  # pylint: disable=too-many-instance-attributes
-    """Folded Morgan Fingerprint.
+    """Folded Path Fingerprint.
 
     Feature-mapping to vector-positions is arbitrary.
 
@@ -99,9 +99,10 @@ class Mol2PathFP(
         )
         if not isinstance(n_bits, int) or n_bits < 1:
             raise ValueError(
-                f"Number of bits has to be a positve integer, which is > 0! (Received: {n_bits})"
+                f"Number of bits has to be a positive integer, which is > 0! (Received: {n_bits})"
             )
         self._n_bits = n_bits
+        self._feature_names = [f"path_{i}" for i in range(self._n_bits)]
         self._min_path = min_path
         self._max_path = max_path
         self._use_hs = use_hs

--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -72,6 +72,7 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
             UUID of the PipelineElement. If None, a new UUID is generated.
         """
         self.descriptor_list = descriptor_list  # type: ignore
+        self._feature_names = self._descriptor_list
         self._return_with_errors = return_with_errors
         self._log_exceptions = log_exceptions
         super().__init__(
@@ -88,7 +89,7 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
 
     @property
     def descriptor_list(self) -> list[str]:
-        """Return a copy of the descriptor list."""
+        """Return a copy of the descriptor list. Alias of `feature_names`."""
         return self._descriptor_list[:]
 
     @descriptor_list.setter

--- a/tests/test_elements/test_mol2any/test_mol2concatenated.py
+++ b/tests/test_elements/test_mol2any/test_mol2concatenated.py
@@ -183,7 +183,7 @@ class TestConcatenatedFingerprint(unittest.TestCase):
                 seen_names = 0
                 for elem_name, elem in elements_subset:
                     self.assertTrue(hasattr(elem, "feature_names"))
-                    elem_feature_names = elem.feature_names
+                    elem_feature_names = elem.feature_names  # type: ignore[attr-defined]
                     elem_n_features = len(elem_feature_names)
                     relevant_names = feature_names[
                         seen_names : seen_names + elem_n_features

--- a/tests/test_elements/test_mol2any/test_mol2concatenated.py
+++ b/tests/test_elements/test_mol2any/test_mol2concatenated.py
@@ -14,7 +14,9 @@ from molpipeline import Pipeline
 from molpipeline.abstract_pipeline_elements.core import MolToAnyPipelineElement
 from molpipeline.any2mol import SmilesToMol
 from molpipeline.mol2any import (
+    Mol2PathFP,
     MolToConcatenatedVector,
+    MolToMACCSFP,
     MolToMorganFP,
     MolToNetCharge,
     MolToRDKitPhysChem,
@@ -166,11 +168,11 @@ class TestConcatenatedFingerprint(unittest.TestCase):
         )
         path_elem = (
             "PathFP",
-            MolToMorganFP(n_bits=15),
+            Mol2PathFP(n_bits=15),
         )
         maccs_elem = (
             "MACCSFP",
-            MolToMorganFP(n_bits=14),
+            MolToMACCSFP(),
         )
 
         elements = [

--- a/tests/test_elements/test_mol2any/test_mol2concatenated.py
+++ b/tests/test_elements/test_mol2any/test_mol2concatenated.py
@@ -137,7 +137,7 @@ class TestConcatenatedFingerprint(unittest.TestCase):
             net_charge_elem[1].n_features + 16 + physchem_elem[1].n_features,
         )
 
-    def test_features_names(self) -> None:  # pylint: disable=too-many-arguments
+    def test_features_names(self) -> None:  # pylint: disable-msg=too-many-locals
         """Test getting the names of features in the concatenated vector."""
 
         physchem_elem = (

--- a/tests/test_elements/test_mol2any/test_mol2concatenated.py
+++ b/tests/test_elements/test_mol2any/test_mol2concatenated.py
@@ -137,7 +137,7 @@ class TestConcatenatedFingerprint(unittest.TestCase):
             net_charge_elem[1].n_features + 16 + physchem_elem[1].n_features,
         )
 
-    def test_features_names(self) -> None:
+    def test_features_names(self) -> None:  # pylint: disable=too-many-arguments
         """Test getting the names of features in the concatenated vector."""
 
         physchem_elem = (
@@ -170,7 +170,7 @@ class TestConcatenatedFingerprint(unittest.TestCase):
 
             for elements_subset in powerset:
                 conc_elem = MolToConcatenatedVector(
-                    elements_subset, feature_names_prefix=feature_names_prefix
+                    list(elements_subset), feature_names_prefix=feature_names_prefix
                 )
                 feature_names = conc_elem.feature_names
 
@@ -182,6 +182,7 @@ class TestConcatenatedFingerprint(unittest.TestCase):
 
                 seen_names = 0
                 for elem_name, elem in elements_subset:
+                    self.assertTrue(hasattr(elem, "feature_names"))
                     elem_feature_names = elem.feature_names
                     elem_n_features = len(elem_feature_names)
                     relevant_names = feature_names[

--- a/tests/test_elements/test_mol2any/test_mol2concatenated.py
+++ b/tests/test_elements/test_mol2any/test_mol2concatenated.py
@@ -11,6 +11,7 @@ from rdkit import Chem
 from sklearn.preprocessing import StandardScaler
 
 from molpipeline import Pipeline
+from molpipeline.abstract_pipeline_elements.core import MolToAnyPipelineElement
 from molpipeline.any2mol import SmilesToMol
 from molpipeline.mol2any import (
     MolToConcatenatedVector,
@@ -234,7 +235,7 @@ class TestConcatenatedFingerprint(unittest.TestCase):
 
     def test_logging_feature_names_uniqueness(self) -> None:
         """Test that a warning is logged when feature names are not unique."""
-        elements = [
+        elements: list[tuple[str, MolToAnyPipelineElement]] = [
             (
                 "MorganFP",
                 MolToMorganFP(n_bits=17),
@@ -282,7 +283,7 @@ class TestConcatenatedFingerprint(unittest.TestCase):
 
     def test_getter_setter(self) -> None:
         """Test getter and setter methods."""
-        elements = [
+        elements: list[tuple[str, MolToAnyPipelineElement]] = [
             (
                 "MorganFP",
                 MolToMorganFP(n_bits=17),

--- a/tests/test_elements/test_mol2any/test_mol2maccs_key_fingerprint.py
+++ b/tests/test_elements/test_mol2any/test_mol2maccs_key_fingerprint.py
@@ -99,6 +99,14 @@ class TestMolToMACCSFP(unittest.TestCase):
         }
         self.assertRaises(ValueError, mol_fp.set_params, **params)
 
+    def test_feature_names(self) -> None:
+        """Test if the feature names are correct."""
+        mol_fp = MolToMACCSFP()
+        feature_names = mol_fp.feature_names
+        self.assertEqual(len(feature_names), mol_fp.n_bits)
+        # feature names should be unique
+        self.assertEqual(len(feature_names), len(set(feature_names)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_elements/test_mol2any/test_mol2morgan_fingerprint.py
+++ b/tests/test_elements/test_mol2any/test_mol2morgan_fingerprint.py
@@ -149,6 +149,14 @@ class TestMol2MorganFingerprint(unittest.TestCase):
                     np_fp = fingerprints_to_numpy(fp)
                     self.assertEqual(np.nonzero(np_fp)[0].shape[0], len(mapping))  # type: ignore
 
+    def test_feature_names(self) -> None:
+        """Test if the feature names are correct."""
+        mol_fp = MolToMorganFP(n_bits=1024)
+        feature_names = mol_fp.feature_names
+        self.assertEqual(len(feature_names), 1024)
+        # feature names should be unique
+        self.assertEqual(len(feature_names), len(set(feature_names)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_elements/test_mol2any/test_mol2path_fingerprint.py
+++ b/tests/test_elements/test_mol2any/test_mol2path_fingerprint.py
@@ -142,6 +142,14 @@ class TestMol2PathFingerprint(unittest.TestCase):
         }
         self.assertRaises(ValueError, mol_fp.set_params, **params)
 
+    def test_feature_names(self) -> None:
+        """Test if the feature names are correct."""
+        mol_fp = Mol2PathFP(n_bits=1024)
+        feature_names = mol_fp.feature_names
+        self.assertEqual(len(feature_names), 1024)
+        # feature names should be unique
+        self.assertEqual(len(feature_names), len(set(feature_names)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils/logging.py
+++ b/tests/utils/logging.py
@@ -1,0 +1,24 @@
+"""Test utils for logging."""
+from contextlib import contextmanager
+from typing import Generator
+
+from loguru import logger
+
+@contextmanager
+def capture_logs(level="INFO", format="{level}:{name}:{message}") -> Generator[list[str], None, None]:
+    """Capture loguru-based logs.
+
+    Custom context manager to test loguru-based logs. For details and usage examples,
+    see https://loguru.readthedocs.io/en/latest/resources/migration.html#replacing-assertlogs-method-from-unittest-library
+
+    Parameters
+    ----------
+    level : str, optional
+        Log level, by default "INFO"
+    format : str, optional
+        Log format, by default "{level}:{name}:{message}"
+    """
+    output: list[str] = []
+    handler_id = logger.add(output.append, level=level, format=format)
+    yield output
+    logger.remove(handler_id)

--- a/tests/utils/logging.py
+++ b/tests/utils/logging.py
@@ -1,15 +1,18 @@
 """Test utils for logging."""
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 from typing import Generator
 
+import loguru
 from loguru import logger
 
 
 @contextmanager
 def capture_logs(
     level="INFO", format="{level}:{name}:{message}"
-) -> Generator[list[str], None, None]:
+) -> Generator[list[loguru.Message], None, None]:  # ign
     """Capture loguru-based logs.
 
     Custom context manager to test loguru-based logs. For details and usage examples,
@@ -24,10 +27,15 @@ def capture_logs(
 
     Yields
     -------
-    list[str]
+    list[loguru.Message]
+        List of log messages
+
+    Returns
+    -------
+    Generator[list[loguru.Message], None, None]
         List of log messages
     """
-    output: list[str] = []
+    output: list[loguru.Message] = []
     handler_id = logger.add(output.append, level=level, format=format)
     yield output
     logger.remove(handler_id)

--- a/tests/utils/logging.py
+++ b/tests/utils/logging.py
@@ -11,8 +11,8 @@ from loguru import logger
 
 @contextmanager
 def capture_logs(
-    level="INFO", format="{level}:{name}:{message}"
-) -> Generator[list[loguru.Message], None, None]:  # ign
+    level: str = "INFO", format: str = "{level}:{name}:{message}"
+) -> Generator[list[loguru.Message], None, None]:
     """Capture loguru-based logs.
 
     Custom context manager to test loguru-based logs. For details and usage examples,

--- a/tests/utils/logging.py
+++ b/tests/utils/logging.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 @contextmanager
 def capture_logs(
-    level: str = "INFO", format: str = "{level}:{name}:{message}"
+    level: str = "INFO", log_format: str = "{level}:{name}:{message}"
 ) -> Generator[list[loguru.Message], None, None]:
     """Capture loguru-based logs.
 
@@ -22,7 +22,7 @@ def capture_logs(
     ----------
     level : str, optional
         Log level, by default "INFO"
-    format : str, optional
+    log_format : str, optional
         Log format, by default "{level}:{name}:{message}"
 
     Yields
@@ -36,6 +36,6 @@ def capture_logs(
         List of log messages
     """
     output: list[loguru.Message] = []
-    handler_id = logger.add(output.append, level=level, format=format)
+    handler_id = logger.add(output.append, level=level, format=log_format)
     yield output
     logger.remove(handler_id)

--- a/tests/utils/logging.py
+++ b/tests/utils/logging.py
@@ -1,11 +1,15 @@
 """Test utils for logging."""
+
 from contextlib import contextmanager
 from typing import Generator
 
 from loguru import logger
 
+
 @contextmanager
-def capture_logs(level="INFO", format="{level}:{name}:{message}") -> Generator[list[str], None, None]:
+def capture_logs(
+    level="INFO", format="{level}:{name}:{message}"
+) -> Generator[list[str], None, None]:
     """Capture loguru-based logs.
 
     Custom context manager to test loguru-based logs. For details and usage examples,
@@ -17,6 +21,11 @@ def capture_logs(level="INFO", format="{level}:{name}:{message}") -> Generator[l
         Log level, by default "INFO"
     format : str, optional
         Log format, by default "{level}:{name}:{message}"
+
+    Yields
+    -------
+    list[str]
+        List of log messages
     """
     output: list[str] = []
     handler_id = logger.add(output.append, level=level, format=format)


### PR DESCRIPTION
    - Feature names could not be extracted from fingerprint pipeline elements.
    - Added common interface to get names for fingerprints and descriptors.