### PR TITLE
replace base_estimator's self._validate_data with validate_data

### DIFF
--- a/molpipeline/estimators/connected_component_clustering.py
+++ b/molpipeline/estimators/connected_component_clustering.py
@@ -11,6 +11,7 @@ from scipy import sparse
 from scipy.sparse import csr_matrix
 from sklearn.base import BaseEstimator, ClusterMixin, _fit_context
 from sklearn.utils._param_validation import Interval
+from sklearn.utils.validation import validate_data
 
 try:
     from typing import Self
@@ -72,7 +73,7 @@ class ConnectedComponentClustering(ClusterMixin, BaseEstimator):
         Self
             Fitted estimator.
         """
-        X = self._validate_data(X, ensure_min_samples=2, accept_sparse=True)
+        X = validate_data(self, X=X, ensure_min_samples=2, accept_sparse=True)
         return self._fit(X)
 
     # pylint: disable=C0103,W0613

--- a/molpipeline/estimators/murcko_scaffold_clustering.py
+++ b/molpipeline/estimators/murcko_scaffold_clustering.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.typing as npt
 from sklearn.base import BaseEstimator, ClusterMixin, _fit_context
 from sklearn.preprocessing import FunctionTransformer, OrdinalEncoder
+from sklearn.utils.validation import validate_data
 
 from molpipeline import ErrorFilter, FilterReinserter, Pipeline
 from molpipeline.any2mol import AutoToMol
@@ -165,7 +166,7 @@ class MurckoScaffoldClustering(ClusterMixin, BaseEstimator):
         Self
             Fitted estimator.
         """
-        X = self._validate_data(X, ensure_min_samples=2, ensure_2d=False, dtype=None)
+        X = validate_data(self, X=X, ensure_min_samples=2, ensure_2d=False, dtype=None)
         return self._fit(X)
 
     # pylint: disable=C0103,W0613


### PR DESCRIPTION
    - In sklearn 1.7 the self._validate_data will be deprecated. To comply and avoid FutureWarnings, we adapt to this change.