### PR TITLE
130 add fix attribute output type

### DIFF
--- a/molpipeline/abstract_pipeline_elements/mol2any/mol2bitvector.py
+++ b/molpipeline/abstract_pipeline_elements/mol2any/mol2bitvector.py
@@ -330,6 +330,13 @@ class MolToRDKitGenFPElement(MolToFingerprintPipelineElement, abc.ABC):
 class ABCMorganFingerprintPipelineElement(MolToRDKitGenFPElement, abc.ABC):
     """Abstract Class for Morgan fingerprints."""
 
+    @property
+    def output_type(self) -> str:
+        """Get output type."""
+        if self.counted:
+            return "integer"
+        return "binary"
+
     # pylint: disable=R0913
     def __init__(
         self,

--- a/molpipeline/estimators/chemprop/neural_fingerprint.py
+++ b/molpipeline/estimators/chemprop/neural_fingerprint.py
@@ -12,7 +12,17 @@ from molpipeline.estimators.chemprop.abstract import ABCChemprop
 
 
 class ChempropNeuralFP(ABCChemprop):
-    """Wrap Chemprop in a sklearn like transformer returning the neural fingerprint as a numpy array."""
+    """Wrap Chemprop in a sklearn like transformer returning the neural fingerprint as a numpy array.
+
+    This class is not a (grand-) child of MolToAnyPipelineElement, as it does not support the `pretransform_single`
+    method. To maintain compatibility with the MolToAnyPipelineElement, the `output_type` property is implemented.
+    It can be used as any other transformer in the pipeline, except in the `MolToConcatenatedVector`.
+    """
+
+    @property
+    def output_type(self) -> str:
+        """Return the output type of the transformer."""
+        return "float"
 
     def __init__(
         self,

--- a/molpipeline/estimators/chemprop/neural_fingerprint.py
+++ b/molpipeline/estimators/chemprop/neural_fingerprint.py
@@ -62,7 +62,7 @@ class ChempropNeuralFP(ABCChemprop):
 
     def fit(
         self,
-        X: MoleculeDataset,  # pylint: disable=invalid-name
+        X: MoleculeDataset,
         y: Sequence[int | float] | npt.NDArray[np.int_ | np.float64],
     ) -> Self:
         """Fit the model.

--- a/test_extras/test_chemprop/test_neural_fingerprint.py
+++ b/test_extras/test_chemprop/test_neural_fingerprint.py
@@ -33,3 +33,8 @@ class TestChempropNeuralFingerprint(unittest.TestCase):
         chemprop_json = recursive_to_json(chemprop_fp_encoder)
         chemprop_encoder_copy = recursive_from_json(chemprop_json)
         compare_params(self, chemprop_fp_encoder, chemprop_encoder_copy)
+
+    def test_output_type(self) -> None:
+        """Test the output type."""
+        chemprop_fp_encoder = get_neural_fp_encoder()
+        self.assertEqual(chemprop_fp_encoder.output_type, "float")

--- a/tests/test_elements/test_mol2any/test_mol2morgan_fingerprint.py
+++ b/tests/test_elements/test_mol2any/test_mol2morgan_fingerprint.py
@@ -63,6 +63,13 @@ class TestMol2MorganFingerprint(unittest.TestCase):
         self.assertTrue(np.any(output_counted > output_binary))
 
     def test_output_types(self) -> None:
+        """Test if the output types are correct for counted and binary fingerprints."""
+        mol_fp = MolToMorganFP(counted=False)
+        self.assertEqual(mol_fp.output_type, "binary")
+        mol_fp = MolToMorganFP(counted=True)
+        self.assertEqual(mol_fp.output_type, "integer")
+
+    def test_return_value_types(self) -> None:
         """Test equality of different output_types."""
 
         smi2mol = SmilesToMol()


### PR DESCRIPTION
Solves https://github.com/basf/MolPipeline/issues/130
ToDos:
 - [x] Add `output_type ` to `ChempropNeuralFP`
 - [x] Make `output_type` of `MolToMorganFP ` depend on the attribute `counted`
 - [x] Add unit tests