### PR TITLE
move version from pyproject.toml to __init__

### DIFF
--- a/molpipeline/__init__.py
+++ b/molpipeline/__init__.py
@@ -12,8 +12,11 @@ from molpipeline.post_prediction import PostPredictionWrapper
 SetDefaultPickleProperties(PropertyPickleOptions.AllProps)
 
 __all__ = [
+    "__version__",
     "Pipeline",
     "ErrorFilter",
     "FilterReinserter",
     "PostPredictionWrapper",
 ]
+
+__version__ = "0.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-dynamic = ["dependencies", "optional-dependencies"]
+dynamic = ["dependencies", "optional-dependencies", "version"]
 name = "molpipeline"
 authors = [
     {name = "Christian W. Feldmann"},
@@ -11,11 +11,11 @@ authors = [
     {name = "Jochen Sieg"}
 ]
 description = "Integration of rdkit functionality into sklearn pipelines."
-version = "0.9.2"
 readme = "README.md"
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
+version = {attr = "molpipeline.__version__"}
 
 [tool.setuptools.dynamic.optional-dependencies]
 all = {file = ["requirements_chemprop.txt", "requirements_notebooks.txt"]}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,18 @@
+"""Test functionality set at package init."""
+
+import unittest
+
+from molpipeline import __version__
+
+
+class TestInit(unittest.TestCase):
+
+    def test_version(self):
+        """Test that the package has a version."""
+        self.assertIsInstance(__version__, str)
+        splitted = __version__.split(".")
+        self.assertEqual(len(splitted), 3)
+        major, minor, patch = splitted
+        self.assertTrue(major.isdigit())
+        self.assertTrue(minor.isdigit())
+        self.assertTrue(patch.isdigit())


### PR DESCRIPTION
Solves https://github.com/basf/MolPipeline/issues/125

Move the package version from the pyproject.toml to molpipeline/__init__.py. Now we can do things like:

```python
import molpipeline
print(molpipeline.__version__)
```