### PR TITLE
remove setuptools from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ numpy
 pandas
 rdkit >= 2023.9.1
 scipy
-setuptools
 shap
 scikit-learn >= 1.6.0
 typing_extensions


### PR DESCRIPTION
setuptools  should not longer be a requirement for molipeline.

ToDo:
 - [x] remove from requirements.txt