### PR TITLE
Add chemprop multiple/multi-target regression

### DIFF
--- a/test_extras/test_chemprop/chemprop_test_utils/constant_vars.py
+++ b/test_extras/test_chemprop/chemprop_test_utils/constant_vars.py
@@ -1,5 +1,7 @@
 """Variables that are used in multiple tests."""
 
+from copy import deepcopy
+
 from chemprop.nn import BCELoss
 from torch import Tensor, nn
 
@@ -161,6 +163,8 @@ DEFAULT_SET_PARAMS = {
     "n_jobs": 1,
 }
 
+DEFAULT_REGRESSION_PARAMS = deepcopy(DEFAULT_BINARY_CLASSIFICATION_PARAMS)
+DEFAULT_REGRESSION_PARAMS.update({"n_tasks": 1})
 
 DEFAULT_MULTICLASS_CLASSIFICATION_PARAMS = {
     "batch_size": 64,

--- a/test_extras/test_chemprop/test_chemprop_pipeline.py
+++ b/test_extras/test_chemprop/test_chemprop_pipeline.py
@@ -114,8 +114,13 @@ DEFAULT_TRAINER = pl.Trainer(
 )
 
 
-def get_regression_pipeline() -> Pipeline:
+def get_regression_pipeline(n_tasks: int = 1) -> Pipeline:
     """Get the Chemprop model pipeline for regression.
+
+    Parameters
+    ----------
+    n_tasks : int
+        The number of tasks for model initialization, i.e. number of target variables.
 
     Returns
     -------
@@ -129,7 +134,9 @@ def get_regression_pipeline() -> Pipeline:
     filter_reinserter = FilterReinserter.from_error_filter(
         error_filter, fill_value=np.nan
     )
-    chemprop_model = ChempropRegressor(lightning_trainer=DEFAULT_TRAINER)
+    chemprop_model = ChempropRegressor(
+        lightning_trainer=DEFAULT_TRAINER, n_tasks=n_tasks
+    )
     model_pipeline = Pipeline(
         steps=[
             ("smiles2mol", smiles2mol),
@@ -341,6 +348,48 @@ class TestRegressionPipeline(unittest.TestCase):
             [molecule_net_logd_df["smiles"].iloc[0]]
         )
         self.assertEqual(single_mol_pred.shape, (1,))
+
+
+class TestMultiRegressionPipeline(unittest.TestCase):
+    """Test the Chemprop model pipeline for multi-target/multiple regression."""
+
+    def test_prediction(self) -> None:
+        """Test the prediction of the multiple regression model."""
+
+        molecule_net_logd_df = pd.read_csv(
+            TEST_DATA_DIR / "molecule_net_logd.tsv.gz", sep="\t", nrows=100
+        )
+
+        # add another target col with gaussian noise
+        rng = np.random.default_rng(seed=123)
+        molecule_net_logd_df["exp2"] = molecule_net_logd_df["exp"] + rng.normal(
+            loc=0.0, scale=1.0, size=molecule_net_logd_df.shape[0]
+        )
+        target_cols = ["exp", "exp2"]
+
+        regression_model = get_regression_pipeline(n_tasks=len(target_cols))
+        regression_model.fit(
+            molecule_net_logd_df["smiles"],
+            molecule_net_logd_df[target_cols].to_numpy(),
+        )
+        pred = regression_model.predict(molecule_net_logd_df["smiles"])
+        self.assertEqual(
+            pred.shape,
+            (
+                len(molecule_net_logd_df),
+                len(target_cols),
+            ),
+        )
+
+        model_copy = joblib_dump_load(regression_model)
+        pred_copy = model_copy.predict(molecule_net_logd_df["smiles"])
+        self.assertTrue(np.allclose(pred, pred_copy))
+
+        # Test single prediction, this was causing an error before
+        single_mol_pred = regression_model.predict(
+            [molecule_net_logd_df["smiles"].iloc[0]]
+        )
+        self.assertEqual(single_mol_pred.shape, (1, len(target_cols)))
 
 
 class TestClassificationPipeline(unittest.TestCase):

--- a/test_extras/test_chemprop/test_models.py
+++ b/test_extras/test_chemprop/test_models.py
@@ -32,6 +32,7 @@ from test_extras.test_chemprop.chemprop_test_utils.constant_vars import (
     DEFAULT_MULTICLASS_CLASSIFICATION_PARAMS,
     DEFAULT_SET_PARAMS,
     NO_IDENTITY_CHECK,
+    DEFAULT_REGRESSION_PARAMS,
 )
 from test_extras.test_chemprop.chemprop_test_utils.default_models import (
     get_chemprop_model_binary_classification_mpnn,
@@ -175,7 +176,7 @@ class TestChempropRegressor(unittest.TestCase):
         """Test the get_params and set_params methods."""
         chemprop_model = ChempropRegressor(lightning_trainer__accelerator="cpu")
         param_dict = chemprop_model.get_params(deep=True)
-        expected_params = dict(DEFAULT_BINARY_CLASSIFICATION_PARAMS)
+        expected_params = dict(DEFAULT_REGRESSION_PARAMS)
         expected_params["model__predictor"] = RegressionFFN
         expected_params["model__predictor__criterion"] = MSELoss
         self.assertSetEqual(set(param_dict.keys()), set(expected_params.keys()))


### PR DESCRIPTION
Add functionality to use chemprop for multiple regression.

This is done by exposing the `n_tasks` parameter in the `ChempropRegressor`.