### PR TITLE
rdkit_phys_chem: set empty descriptor list to default list

### DIFF
--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -106,13 +106,13 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
         ValueError
             If an unknown descriptor name is used.
         """
-        if (
-            descriptor_list is None
-            or len(descriptor_list) == 0
-            or descriptor_list is DEFAULT_DESCRIPTORS
-        ):
+        if descriptor_list is None or descriptor_list is DEFAULT_DESCRIPTORS:
             # if None or DEFAULT_DESCRIPTORS are used, set the default descriptors
             self._descriptor_list = DEFAULT_DESCRIPTORS
+        elif len(descriptor_list) == 0:
+            raise ValueError(
+                "Empty descriptor_list is not allowed. Use None for default descriptors."
+            )
         else:
             # check all user defined descriptors are valid
             for descriptor_name in descriptor_list:

--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -105,6 +105,8 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
         ------
         ValueError
             If an unknown descriptor name is used.
+        ValueError
+            If an empty descriptor_list is used.
         """
         if descriptor_list is None or descriptor_list is DEFAULT_DESCRIPTORS:
             # if None or DEFAULT_DESCRIPTORS are used, set the default descriptors

--- a/molpipeline/mol2any/mol2rdkit_phys_chem.py
+++ b/molpipeline/mol2any/mol2rdkit_phys_chem.py
@@ -106,7 +106,11 @@ class MolToRDKitPhysChem(MolToDescriptorPipelineElement):
         ValueError
             If an unknown descriptor name is used.
         """
-        if descriptor_list is None or descriptor_list is DEFAULT_DESCRIPTORS:
+        if (
+            descriptor_list is None
+            or len(descriptor_list) == 0
+            or descriptor_list is DEFAULT_DESCRIPTORS
+        ):
             # if None or DEFAULT_DESCRIPTORS are used, set the default descriptors
             self._descriptor_list = DEFAULT_DESCRIPTORS
         else:

--- a/tests/test_elements/test_mol2any/test_mol2rdkit_phys_chem.py
+++ b/tests/test_elements/test_mol2any/test_mol2rdkit_phys_chem.py
@@ -403,6 +403,18 @@ class TestMol2RDKitPhyschem(unittest.TestCase):
         output = pipeline.fit_transform(["[HH]"])
         self.assertTrue(output.shape == (1, len(DEFAULT_DESCRIPTORS)))
 
+    def test_empty_descriptor_list(self) -> None:
+        """Test that an empty descriptor list defaults to DEFAULT_DESCRIPTORS."""
+        empty_descriptor_element = MolToRDKitPhysChem(descriptor_list=[])
+
+        # test that the descriptor list is set to DEFAULT_DESCRIPTORS
+        self.assertListEqual(
+            empty_descriptor_element.descriptor_list, DEFAULT_DESCRIPTORS
+        )
+        self.assertListEqual(
+            empty_descriptor_element.feature_names, DEFAULT_DESCRIPTORS
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_elements/test_mol2any/test_mol2rdkit_phys_chem.py
+++ b/tests/test_elements/test_mol2any/test_mol2rdkit_phys_chem.py
@@ -404,15 +404,11 @@ class TestMol2RDKitPhyschem(unittest.TestCase):
         self.assertTrue(output.shape == (1, len(DEFAULT_DESCRIPTORS)))
 
     def test_empty_descriptor_list(self) -> None:
-        """Test that an empty descriptor list defaults to DEFAULT_DESCRIPTORS."""
-        empty_descriptor_element = MolToRDKitPhysChem(descriptor_list=[])
-
-        # test that the descriptor list is set to DEFAULT_DESCRIPTORS
-        self.assertListEqual(
-            empty_descriptor_element.descriptor_list, DEFAULT_DESCRIPTORS
-        )
-        self.assertListEqual(
-            empty_descriptor_element.feature_names, DEFAULT_DESCRIPTORS
+        """Test that an empty descriptor list raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            MolToRDKitPhysChem(descriptor_list=[])
+        self.assertTrue(
+            str(context.exception).startswith("Empty descriptor_list is not allowed")
         )
 
 


### PR DESCRIPTION
Empty descriptor list would lead to unusable MolToRDKitPhysChem. Now, if an empty list is given it's replaced by the default descriptor list.