### PR TITLE
Allow pd.Series input to filter

### DIFF
--- a/molpipeline/abstract_pipeline_elements/mol2mol/filter.py
+++ b/molpipeline/abstract_pipeline_elements/mol2mol/filter.py
@@ -4,6 +4,8 @@ import abc
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal, TypeAlias
 
+import pandas as pd
+
 try:
     from typing import Self  # type: ignore[attr-defined]
 except ImportError:
@@ -54,9 +56,7 @@ def _within_boundaries(
     """
     if lower_bound is not None and property_value < lower_bound:
         return False
-    if upper_bound is not None and property_value > upper_bound:
-        return False
-    return True
+    return not (upper_bound is not None and property_value > upper_bound)
 
 
 class BaseKeepMatchesFilter(MolToMolPipelineElement, abc.ABC):
@@ -65,10 +65,10 @@ class BaseKeepMatchesFilter(MolToMolPipelineElement, abc.ABC):
     Notes
     -----
     There are four possible scenarios:
-        - mode = "any" & keep_matches = True: Needs to match at least one filter element.
-        - mode = "any" & keep_matches = False: Must not match any filter element.
-        - mode = "all" & keep_matches = True: Needs to match all filter elements.
-        - mode = "all" & keep_matches = False: Must not match all filter elements.
+      - mode = "any" & keep_matches = True: Needs to match at least one filter element.
+      - mode = "any" & keep_matches = False: Must not match any filter element.
+      - mode = "all" & keep_matches = True: Needs to match all filter elements.
+      - mode = "all" & keep_matches = False: Must not match all filter elements.
 
     """
 
@@ -77,11 +77,14 @@ class BaseKeepMatchesFilter(MolToMolPipelineElement, abc.ABC):
 
     def __init__(
         self,
-        filter_elements: Mapping[
-            Any,
-            FloatCountRange | IntCountRange | IntOrIntCountRange,
-        ]
-        | Sequence[Any],
+        filter_elements: (
+            Mapping[
+                Any,
+                FloatCountRange | IntCountRange | IntOrIntCountRange,
+            ]
+            | Sequence[Any]
+            | pd.Series
+        ),
         keep_matches: bool = True,
         mode: FilterModeType = "any",
         name: str | None = None,
@@ -92,14 +95,22 @@ class BaseKeepMatchesFilter(MolToMolPipelineElement, abc.ABC):
 
         Parameters
         ----------
-        filter_elements: Union[Mapping[Any, Union[FloatCountRange, IntCountRange, IntOrIntCountRange]], Sequence[Any]]
-            List of filter elements. Typically can be a list of patterns or a dictionary with patterns as keys and
-            an int for exact count or a tuple of minimum and maximum.
-            NOTE: for each child class, the type of filter_elements must be specified by the filter_elements setter.
+        filter_elements: Mapping[
+                Any,
+                FloatCountRange | IntCountRange | IntOrIntCountRange,
+            ]
+            | Sequence[Any]
+            | pd.Series
+            List of filter elements. Typically, can be a list of patterns or a
+            dictionary with patterns as keys and an int for exact count or a tuple of
+            minimum and maximum.
+            NOTE: for each child class, the type of filter_elements must be specified by
+                  the filter_elements setter.
         keep_matches: bool, optional (default: True)
             If True, molecules containing the specified patterns are kept, else removed.
         mode: FilterModeType, optional (default: "any")
-            If "any", at least one of the specified patterns must be present in the molecule.
+            If "any", at least one of the specified patterns must be present in the
+            molecule.
             If "all", all of the specified patterns must be present in the molecule.
         name: Optional[str], optional (default: None)
             Name of the pipeline element.
@@ -180,14 +191,14 @@ class BaseKeepMatchesFilter(MolToMolPipelineElement, abc.ABC):
         params["filter_elements"] = self.filter_elements
         return params
 
-    def pretransform_single(  # pylint: disable=too-many-return-statements
+    def pretransform_single(  # pylint: disable=too-many-return-statements # noqa: PLR0911
         self,
         value: RDKitMol,
     ) -> OptionalMol:
         """Invalidate or validate molecule based on specified filter.
 
         There are four possible scenarios:
-        - mode = "any" & keep_matches = True: Needs to match at least one filter element.
+        - mode = "any" & keep_matches = True: Needs to match at least one filter element
         - mode = "any" & keep_matches = False: Must not match any filter element.
         - mode = "all" & keep_matches = True: Needs to match all filter elements.
         - mode = "all" & keep_matches = False: Must not match all filter elements.
@@ -216,7 +227,8 @@ class BaseKeepMatchesFilter(MolToMolPipelineElement, abc.ABC):
                     if not self.keep_matches:
                         return InvalidInstance(
                             self.uuid,
-                            f"Molecule contains forbidden filter element {filter_element}.",
+                            "Molecule contains forbidden filter element "
+                            f"{filter_element}.",
                             self.name,
                         )
                     return value
@@ -225,7 +237,8 @@ class BaseKeepMatchesFilter(MolToMolPipelineElement, abc.ABC):
                 if self.keep_matches:
                     return InvalidInstance(
                         self.uuid,
-                        f"Molecule does not contain required filter element {filter_element}.",
+                        "Molecule does not contain required filter element"
+                        f" {filter_element}.",
                         self.name,
                     )
                 return value
@@ -239,7 +252,8 @@ class BaseKeepMatchesFilter(MolToMolPipelineElement, abc.ABC):
                     "Molecule does not match any of the required filter elements.",
                     self.name,
                 )
-            #  else: No match with forbidden filter elements was found, return original molecule
+            #  else: No match with forbidden filter elements was found,
+            #        return original molecule
             return value
 
         if self.mode == "all":
@@ -308,22 +322,32 @@ class BasePatternsFilter(BaseKeepMatchesFilter, abc.ABC):
     @filter_elements.setter
     def filter_elements(
         self,
-        patterns: list[str] | Mapping[str, FloatCountRange],
+        patterns: list[str] | set[str] | pd.Series | Mapping[str, FloatCountRange],
     ) -> None:
         """Set allowed filter elements (patterns) as dict.
 
         Parameters
         ----------
-        patterns: Union[list[str], Mapping[str, FloatCountRange]]
-            List of patterns.
+        patterns: list[str] | set[str] | pd.Series | Mapping[str, FloatCountRange]
+            List-like or Mapping data structure of patterns.
+
+        Raises
+        ------
+        ValueError
+            If the patterns are not valid SMILES or SMARTS, or if the type is invalid.
 
         """
-        if isinstance(patterns, (list, set)):
+        if isinstance(patterns, (list, set, pd.Series)):
             self._filter_elements = dict.fromkeys(patterns, (1, None))
-        else:
+        elif isinstance(patterns, dict):
             self._filter_elements = {
                 pat: assure_range(count) for pat, count in patterns.items()
             }
+        else:
+            raise ValueError(
+                "Invalid type for patterns. Must be a list of strings or a dictionary"
+                " with patterns as keys and counts as values.",
+            )
         self.patterns_mol_dict = list(self._filter_elements.keys())  # type: ignore
 
     @property


### PR DESCRIPTION
filter_elements, e.g. SMARTS, could not be provided as `pd.Series`. Now they can.